### PR TITLE
Mood widget implemented for the latest CSS

### DIFF
--- a/assets/scripts/main.js
+++ b/assets/scripts/main.js
@@ -2,6 +2,15 @@ window.addEventListener("DOMContentLoaded", init);
 
 //TODO: add comments for jsdocs and inline comments
 //TODO: adjust css to align with changes made
+
+/**
+ * Initializes the application.
+ * Sets up task, journal, and calendar elements, populates the mood chart,
+ * and adds event listeners for mood selection buttons.
+ *
+ * @async
+ * @returns {Promise<void>} A promise that resolves when initialization is complete.
+ */
 async function init() {
   try {
     const tasksData = 116; //TODO: update acc to todo
@@ -41,6 +50,10 @@ async function init() {
   }
 }
 
+/**
+ * Populates the mood chart with days of the current month.
+ * Colors the days based on saved moods from local storage.
+ */
 function populateMoodChart() {
   const moodChart = document.getElementById("mood-chart");
   const date = new Date();
@@ -85,6 +98,7 @@ function populateMoodChart() {
     dayCell.textContent = day;
     weekRow.appendChild(dayCell);
 
+    //Formatting the string to be correctly stored in the array
     const dateString = `${year}-${String(month + 1).padStart(2, "0")}-${String(
       day
     ).padStart(2, "0")}`;
@@ -99,12 +113,19 @@ function populateMoodChart() {
   }
 }
 
+/**
+ * Updates the mood chart with the selected mood for the current day.
+ * Saves the updated mood to local storage.
+ *
+ * @param {string} mood - The mood selected (sad, neutral, or happy).
+ */
 function updateMoodChart(mood) {
   const date = new Date();
   const day = date.getDate();
   const month = date.getMonth() + 1;
   const year = date.getFullYear();
 
+  //Formatting this way to align with the format in localStorage
   const currentDate = `${year}-${String(month).padStart(2, "0")}-${String(
     day
   ).padStart(2, "0")}`;

--- a/assets/scripts/main.js
+++ b/assets/scripts/main.js
@@ -1,11 +1,126 @@
-window.addEventListener('DOMContentLoaded', init);
+window.addEventListener("DOMContentLoaded", init);
 
+//TODO: add comments for jsdocs and inline comments
+//TODO: adjust css to align with changes made
 async function init() {
-    try {
-      
-    } catch (err) {
-      console.log(`Error loading: ${err}`);
-      return; 
+  try {
+    const tasksData = 116; //TODO: update acc to todo
+    const journalEntries = 30; //TODO: update acc to journal
+    const calEntries = 11; //TODO: update acc to calendar
+    const taskElements = document.createElement("div");
+    const journalElements = document.createElement("div");
+    const calendarElements = document.createElement("div");
+
+    taskElements.innerHTML = `<p>${tasksData}</p>`;
+    journalElements.innerHTML = `<p>${journalEntries}</p>`;
+    calendarElements.innerHTML = `<p>${calEntries}</p>`;
+
+    document.getElementById("widget-todo").appendChild(taskElements);
+    document.getElementById("widget-journal").appendChild(journalElements);
+    document.getElementById("widget-calendar").appendChild(calendarElements);
+
+    populateMoodChart();
+
+    const moodSelection = document.getElementById("mood-today");
+    moodSelection.innerHTML = `
+          <h2>How are you feeling today?</h2>
+          <button class="mood-button" data-mood="sad">😞</button>
+          <button class="mood-button" data-mood="neutral">😐</button>
+          <button class="mood-button" data-mood="happy">😄</button>
+      `;
+
+    document.querySelectorAll(".mood-button").forEach((button) => {
+      button.addEventListener("click", () => {
+        const selectedMood = button.getAttribute("data-mood");
+        updateMoodChart(selectedMood);
+      });
+    });
+  } catch (err) {
+    console.log(`Error loading: ${err}`);
+    return;
+  }
+}
+
+function populateMoodChart() {
+  const moodChart = document.getElementById("mood-chart");
+  const date = new Date();
+  const month = date.getMonth();
+  const year = date.getFullYear();
+  const daysInMonth = new Date(year, month + 1, 0).getDate();
+
+  const firstDay = (new Date(year, month, 1).getDay() + 6) % 7;
+  moodChart.innerHTML =
+    "<h3>Mood Chart - " +
+    date.toLocaleString("default", { month: "long" }) +
+    "</h3>";
+
+  let boxes = 1;
+  let weekRow;
+  for (let i = 0; i < firstDay; i++) {
+    if (i == 0) {
+      weekRow = document.createElement("div");
+      weekRow.classList.add("week-row");
+      moodChart.appendChild(weekRow);
     }
-    
+
+    const emptyCell = document.createElement("div");
+    emptyCell.classList.add("day-box");
+    weekRow.appendChild(emptyCell);
+    boxes++;
+  }
+
+  const savedMoods = JSON.parse(localStorage.getItem("moods") || "{}");
+
+  for (let day = 1; day <= daysInMonth; day++) {
+    if ((boxes - 1) % 7 == 0) {
+      weekRow = document.createElement("div");
+      weekRow.classList.add("week-row");
+      moodChart.appendChild(weekRow);
+    }
+    boxes++;
+
+    const dayCell = document.createElement("div");
+    dayCell.classList.add("day-box");
+    dayCell.id = day;
+    dayCell.textContent = day;
+    weekRow.appendChild(dayCell);
+
+    const dateString = `${year}-${String(month + 1).padStart(2, "0")}-${String(
+      day
+    ).padStart(2, "0")}`;
+    if (savedMoods[dateString]) {
+      const moodColors = {
+        sad: "#063970",
+        neutral: "#2187ab",
+        happy: "#abdbe3",
+      };
+      dayCell.style.backgroundColor = moodColors[savedMoods[dateString]];
+    }
+  }
+}
+
+function updateMoodChart(mood) {
+  const date = new Date();
+  const day = date.getDate();
+  const month = date.getMonth() + 1;
+  const year = date.getFullYear();
+
+  const currentDate = `${year}-${String(month).padStart(2, "0")}-${String(
+    day
+  ).padStart(2, "0")}`;
+  const moodElement = document.getElementById(day);
+
+  if (!moodElement) return;
+
+  const moodColors = {
+    sad: "#063970",
+    neutral: "#2187ab",
+    happy: "#abdbe3",
+  };
+
+  moodElement.style.backgroundColor = moodColors[mood];
+
+  const moods = JSON.parse(localStorage.getItem("moods") || "{}");
+  moods[currentDate] = mood;
+  localStorage.setItem("moods", JSON.stringify(moods));
 }

--- a/assets/scripts/main.js
+++ b/assets/scripts/main.js
@@ -57,10 +57,13 @@ async function init() {
 function populateMoodChart() {
   const moodChart = document.getElementById("mood-chart");
   const date = new Date();
-  const month = date.getMonth();
+  const month = date.getMonth(); // Get the current month (0-11)
   const year = date.getFullYear();
+
+  // Get the number of days in the current month
   const daysInMonth = new Date(year, month + 1, 0).getDate();
 
+  // Calculate the day of the week the first day of the month falls on (0-6, starting with Monday)
   const firstDay = (new Date(year, month, 1).getDay() + 6) % 7;
   moodChart.innerHTML =
     "<h3>Mood Chart - " +
@@ -69,7 +72,11 @@ function populateMoodChart() {
 
   let boxes = 1;
   let weekRow;
+
+  // Create empty cells for the days before the first day of the month
   for (let i = 0; i < firstDay; i++) {
+    
+    // Create a new row for the week if it is the first cell
     if (i == 0) {
       weekRow = document.createElement("div");
       weekRow.classList.add("week-row");
@@ -84,7 +91,10 @@ function populateMoodChart() {
 
   const savedMoods = JSON.parse(localStorage.getItem("moods") || "{}");
 
+  // Create cells for each day of the month
   for (let day = 1; day <= daysInMonth; day++) {
+    
+    // Start a new row for each week
     if ((boxes - 1) % 7 == 0) {
       weekRow = document.createElement("div");
       weekRow.classList.add("week-row");
@@ -98,10 +108,12 @@ function populateMoodChart() {
     dayCell.textContent = day;
     weekRow.appendChild(dayCell);
 
-    //Formatting the string to be correctly stored in the array
+    // Format the date string as YYYY-MM-DD
     const dateString = `${year}-${String(month + 1).padStart(2, "0")}-${String(
       day
     ).padStart(2, "0")}`;
+    
+    // Set the background color of the cell if a mood is saved for this date
     if (savedMoods[dateString]) {
       const moodColors = {
         sad: "#063970",
@@ -122,7 +134,7 @@ function populateMoodChart() {
 function updateMoodChart(mood) {
   const date = new Date();
   const day = date.getDate();
-  const month = date.getMonth() + 1;
+  const month = date.getMonth() + 1; 
   const year = date.getFullYear();
 
   //Formatting this way to align with the format in localStorage

--- a/assets/scripts/main.js
+++ b/assets/scripts/main.js
@@ -1,6 +1,5 @@
 window.addEventListener("DOMContentLoaded", init);
 
-//TODO: add comments for jsdocs and inline comments
 //TODO: adjust css to align with changes made
 
 /**
@@ -75,7 +74,6 @@ function populateMoodChart() {
 
   // Create empty cells for the days before the first day of the month
   for (let i = 0; i < firstDay; i++) {
-    
     // Create a new row for the week if it is the first cell
     if (i == 0) {
       weekRow = document.createElement("div");
@@ -93,7 +91,6 @@ function populateMoodChart() {
 
   // Create cells for each day of the month
   for (let day = 1; day <= daysInMonth; day++) {
-    
     // Start a new row for each week
     if ((boxes - 1) % 7 == 0) {
       weekRow = document.createElement("div");
@@ -112,7 +109,7 @@ function populateMoodChart() {
     const dateString = `${year}-${String(month + 1).padStart(2, "0")}-${String(
       day
     ).padStart(2, "0")}`;
-    
+
     // Set the background color of the cell if a mood is saved for this date
     if (savedMoods[dateString]) {
       const moodColors = {
@@ -134,7 +131,7 @@ function populateMoodChart() {
 function updateMoodChart(mood) {
   const date = new Date();
   const day = date.getDate();
-  const month = date.getMonth() + 1; 
+  const month = date.getMonth() + 1;
   const year = date.getFullYear();
 
   //Formatting this way to align with the format in localStorage

--- a/assets/scripts/main.js
+++ b/assets/scripts/main.js
@@ -8,7 +8,8 @@ window.addEventListener("DOMContentLoaded", init);
  * and adds event listeners for mood selection buttons.
  *
  * @async
- * @returns {Promise<void>} A promise that resolves when initialization is complete.
+ * @function init
+ * @return {Promise<void>} A promise that resolves when initialization is complete.
  */
 async function init() {
   try {

--- a/assets/styles/main.css
+++ b/assets/styles/main.css
@@ -50,7 +50,7 @@ a {
   justify-content: space-around;
 }
 
-.nav-icon{
+.nav-icon {
   margin-right: 10px;
 }
 
@@ -90,4 +90,54 @@ a {
 .dashboard-widget:nth-child(n + 4) {
   width: calc(30% - 10px);
   height: 30%;
+}
+
+.day-box {
+  display: inline-block;
+  width: 30px;
+  height: 30px;
+  background-color: white;
+  margin: 2px;
+  border-radius: 4px;
+  line-height: 30px;
+  text-align: center;
+  border-color: black;
+  color: rgb(228, 228, 228);
+}
+
+.week-row {
+  display: flex;
+  flex-wrap: wrap;
+  margin-bottom: 10px;
+}
+
+#mood-chart,
+#mood-today {
+  display: inline-block;
+  margin-right: 30px;
+}
+
+#mood-chart {
+  margin-top: 10px;
+  max-width: 100%;
+  max-height: 100%;
+  overflow: auto;
+  box-sizing: border-box;
+}
+
+#mood-chart h3 {
+  margin: 0 0 10px 0;
+  text-align: center;
+}
+
+#mood-chart .week-row {
+  display: flex;
+  flex-wrap: nowrap;
+  justify-content: center;
+}
+
+button {
+  height: 50px;
+  width: 50px;
+  margin-right: 10%;
 }

--- a/source/index.html
+++ b/source/index.html
@@ -64,11 +64,17 @@
       </nav>
 
       <main class="main-canvas">
-        <span class="dashboard-widget"> Number of Tasks: </span>
-        <span class="dashboard-widget"> Number of Journals: </span>
-        <span class="dashboard-widget"> Calendar Entries:</span>
-        <span class="dashboard-widget"> Mood Chart:</span>
-        <span class="dashboard-widget"> Mood Widget:</span>
+        <span class="dashboard-widget" id="widget-todo">
+          Number of Tasks:
+        </span>
+        <span class="dashboard-widget" id="widget-journal">
+          Number of Journals:
+        </span>
+        <span class="dashboard-widget" id="widget-calendar">
+          Calendar Entries:</span
+        >
+        <span class="dashboard-widget" id="mood-chart"> Mood Chart:</span>
+        <span class="dashboard-widget" id="mood-today"> Mood Widget:</span>
       </main>
     </div>
   </body>


### PR DESCRIPTION

# Objectives
The purpose of this PR is to have the mood widget implemented for the issue #91 

### Solution
- made changes to index.html, main.css, main.js to integrate the mood widget
- current display:
<img width="952" alt="image" src="https://github.com/cse110-sp24-group30/cse110-sp24-group30/assets/125161884/3f1b227c-d51a-4de0-8570-3f4ef4ed3fb9">


### Assignees
- @shjucsd 

### Additional Notes 
The CSS needs to be updated so that the mood chart appears along with the mood-today selection column. Integrate the number of tasks/journal/calendar entries to be in sync with the actual widgets instead of hard coded data. 