### PR TITLE
[Journal/Calendar] Sync Journals to Calendar

### DIFF
--- a/journal/journal-app.js
+++ b/journal/journal-app.js
@@ -35,7 +35,8 @@ function addJournalNew(journalContainer, existing) {
     const journalTemplate = {
         id: Math.floor(Math.random() * 2000000),
         title: randomTitle,
-        content: `# ${randomTitle}`
+        content: `# ${randomTitle}`,
+        date: getCurrentDate()
     };
 
     const modalRef = document.getElementById('modal');
@@ -202,7 +203,8 @@ function openJournalModal(event) {
     // Use closest to find the parent element with the journal-widget class
     const widget = event.target.closest('.journal-widget');
     const currentJournalID = widget.getAttribute('widget-id'); // Correctly get the widget-id
-    
+    updateWidgetDate(currentJournalID);
+
     const journalEntries = document.querySelectorAll('.journal-entry');
     hideOtherJournalEntries(journalEntries, currentJournalID);
     let modal = document.getElementById('modal');
@@ -234,7 +236,7 @@ function deleteJournal(event) {
 
     // Remove the journal element from the DOM
     widget.remove();
-    entry.remove()
+    entry.remove();
 
     // Remove the journal entry from localStorage
     const journalList = getJournals();
@@ -285,7 +287,16 @@ function createSaveCancelButtons(modalRef) {
     // Event listener for save button
     saveButton.addEventListener('click', saveContent);
 
+    // Create the 'Link to Calendar' button
+    let linkCalendarButton = document.createElement('button');
+    linkCalendarButton.innerText = 'Link to Calendar';
+    linkCalendarButton.className = 'link-calendar-button';
+
+    // Event listener for link button
+    linkCalendarButton.addEventListener('click', linkCalendar);
+
     buttonContainer.append(saveButton);
+    buttonContainer.append(linkCalendarButton);
     buttonContainer.append(cancelButton);
     modalRef.append(buttonContainer);
 }
@@ -369,6 +380,7 @@ function searchJournals() {
             widget.style.display = 'none';
         }
     });
+}
 
 /**
  * Generates a random title from a predefined list of titles
@@ -429,4 +441,44 @@ function generateRandomTitle() {
     ];
     const randomIndex = Math.floor(Math.random() * titles.length);
     return titles[randomIndex];
+}
+
+/**
+ * Gets the current date of the user's system
+ * 
+ * @returns {String} - A readable string format to the year-month-day of the date
+ */
+function getCurrentDate() {
+    const date = new Date();
+    let day = date.getDate();
+    let month = date.getMonth();
+    let year = date.getFullYear();
+
+    return `${year}-${String(month + 1).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
+}
+
+/**
+ * Updates the "pop-up" date on the top right corner based on the current journal's date creation
+ * 
+ * @param {String} journalID - A journal's unique ID
+ */
+function updateWidgetDate(journalID) {
+    const dateDisplay = document.getElementById('date-display');
+    const journalList = getJournals();
+
+    // Find the journal with the matching ID
+    const journal = journalList.find(journal => journal.id == journalID);
+    dateDisplay.innerText = journal.date;
+}
+
+/**
+ * Links a journal to the calendar upon button press
+ * 
+ * TODO: link current journal to calendar day
+ */
+function linkCalendar() {
+    
+    // TODO:
+
+    alert('Journal linked to calendar!');
 }

--- a/journal/journal-page.html
+++ b/journal/journal-page.html
@@ -36,6 +36,15 @@
     </div>
     <div id="overlay"></div>
     <div id="modal">
+        <div id="date-display"></div>
+        <div id="subtitles">
+            <div id="markdown-title">
+                Markdown
+            </div>
+            <div id="preview-title">
+                Preview
+            </div>
+        </div>
         <!--Below, journal contents will dynamically be added-->
     </div>
 </body>

--- a/journal/journal-style.css
+++ b/journal/journal-style.css
@@ -78,9 +78,6 @@ nav {
     width: 14in;
     height: 6in;
     
-    overflow-y: scroll;
-    overflow-x: hidden;
-    
     display: flex;
     justify-content: center;
     align-items: center;
@@ -158,11 +155,39 @@ nav {
 .save-cancel-container {
     display: flex;
     justify-content: space-around;
-    margin-top: 10px;
+
+    position: relative;
+    bottom: 2.5vh
 }
 
 /* Save/Cancel Buttons */
 .save-button, .cancel-button {
     padding: 5px 10px;
     cursor: pointer;
+}
+
+#subtitles {
+    display: flex;
+    justify-content: space-around;
+    align-items: flex-start;
+    width: 100%;
+
+    position: relative;
+    top: 6vh;
+    font-size: 4vh;
+}
+
+#markdown-title {
+    position: relative;
+    left: 2vw;
+}
+
+#preview-title {
+    position: relative;
+    right: 3vw;
+}
+
+#date-display {
+    position: relative;
+    text-align: end;
 }


### PR DESCRIPTION
# Objective
Refer to the corresponding GitHub issue #100.

The purpose of this PR is to implement a way to sync or link up the journals to the calendar.

![image](https://github.com/cse110-sp24-group30/cse110-sp24-group30/assets/103289124/4fcbf0f7-1f0f-4cbe-b500-139508bfaa12)

## Solution

- Add new function called `getCurrentDate()`, `updateWidgetDate()`, `linkCalendar()`
- Updated `journal-page.html` for date display
- Updated `journal-page.css` for minor alignments

### Assignees
- @kennethkietvuong 

### Additional Notes
The function `linkCalendar()` is blank. This is mostly for the calendar team to fill in, as I do not have much knowledge on how the calendar module is implemented. This function is linked to a button press, so when the `Link to Calendar` button is pressed, the current journal should be displayed on the corresponding calendar page based on the day.
