### PR TITLE
[Calendar] Improved Search Functionality, added an Add Task button to day view, and made several minor improvements

### DIFF
--- a/source/calendar/calendar-app.js
+++ b/source/calendar/calendar-app.js
@@ -36,6 +36,14 @@ document.addEventListener("DOMContentLoaded", () => {
 
     const events = getEvents();
 
+    if (currentView != "day") {
+      document.getElementById("day-view").style.display = "none";
+      document.querySelector(".add-button").style.display = "none";
+    } else {
+      document.getElementById("day-view").style.display = "flex";
+      document.querySelector(".add-button").style.display = "block";
+    }
+
     if (currentView === "month") {
       renderMonthView(firstDayOfMonth, daysInMonth, month, year, events);
     } else if (currentView === "week") {
@@ -548,14 +556,31 @@ document.addEventListener("DOMContentLoaded", () => {
   });
 
   searchBar.addEventListener("input", (event) => {
+    //Hide the day view, make the calendar-grid visible, and hide the week headers
+    document.getElementById("day-view").style.display = "none";
+    document.querySelector(".add-button").style.display = "none";
+    document.getElementById("calendar-grid").style.display = "grid";
+    document.getElementById("calendar-days").style.display = "none";
+
     const query = event.target.value.toLowerCase();
     const events = getEvents();
-    const filteredEvents = events.filter(
-      (event) =>
-        event.title.toLowerCase().includes(query) ||
-        event.description.toLowerCase().includes(query)
-    );
-    renderFilteredEvents(filteredEvents);
+
+    if (query == "") {
+      if (currentView === "day") {
+        document.getElementById("day-view").style.display = "flex";
+        document.querySelector(".add-button").style.display = "block";
+      }
+
+      renderCalendar(currentDate);
+    } else {
+      const filteredEvents = events.filter(
+        (event) =>
+          event.title.toLowerCase().includes(query) ||
+          event.description.toLowerCase().includes(query)
+      );
+
+      renderFilteredEvents(filteredEvents);
+    }
   });
 
   /**
@@ -568,6 +593,7 @@ document.addEventListener("DOMContentLoaded", () => {
     events.forEach((event) => {
       const eventElement = document.createElement("div");
       eventElement.classList.add("event", event.category);
+      eventElement.classList.add("results");
       eventElement.textContent = event.title;
       calendarGrid.appendChild(eventElement);
 

--- a/source/calendar/calendar-app.js
+++ b/source/calendar/calendar-app.js
@@ -45,7 +45,6 @@ document.addEventListener("DOMContentLoaded", () => {
     }
 
     renderTodaySection();
-    renderUpcomingSection();
   };
 
   /**
@@ -258,6 +257,7 @@ document.addEventListener("DOMContentLoaded", () => {
     currentView = event.target.value;
     if (currentView === "day") {
       document.getElementById("day-view").style.display = "flex";
+      document.querySelector(".add-button").style.display = "block";
       document.getElementById("calendar-grid").style.display = "none";
       document.getElementById("calendar-days").style.display = "none"; // Hide the week headers
       renderDayView(
@@ -268,6 +268,7 @@ document.addEventListener("DOMContentLoaded", () => {
       );
     } else {
       document.getElementById("day-view").style.display = "none";
+      document.querySelector(".add-button").style.display = "none";
       document.getElementById("calendar-grid").style.display = "grid";
       document.getElementById("calendar-days").style.display = ""; // Show the week headers
       renderCalendar(currentDate);
@@ -278,6 +279,7 @@ document.addEventListener("DOMContentLoaded", () => {
     currentView = event.target.value;
     if (currentView === "day") {
       document.getElementById("day-view").style.display = "flex";
+      document.querySelector(".add-button").style.display = "block";
       document.getElementById("calendar-grid").style.display = "none";
       renderDayView(
         currentDate.getDate(),
@@ -287,6 +289,7 @@ document.addEventListener("DOMContentLoaded", () => {
       );
     } else {
       document.getElementById("day-view").style.display = "none";
+      document.querySelector(".add-button").style.display = "none";
       document.getElementById("calendar-grid").style.display = "grid";
       renderCalendar(currentDate);
     }
@@ -296,6 +299,7 @@ document.addEventListener("DOMContentLoaded", () => {
     currentView = event.target.value;
     if (currentView === "day") {
       document.getElementById("day-view").style.display = "flex";
+      document.querySelector(".add-button").style.display = "block";
       document.getElementById("calendar-grid").style.display = "none";
       document.getElementById("calendar-days").style.display = "none"; // Hide the week headers
       renderDayView(
@@ -306,6 +310,7 @@ document.addEventListener("DOMContentLoaded", () => {
       );
     } else {
       document.getElementById("day-view").style.display = "none";
+      document.querySelector(".add-button").style.display = "none";
       document.getElementById("calendar-grid").style.display = "grid";
       document.getElementById("calendar-days").style.display = "grid"; // Show the week headers
       renderCalendar(currentDate);
@@ -367,6 +372,30 @@ document.addEventListener("DOMContentLoaded", () => {
           eventModal.style.display = "flex";
         }
       });
+    });
+
+    document.querySelector(".add-button").addEventListener("click", (event) => {
+      let dateStr = currentMonthYear.innerText;
+
+      dateStr = dateStr.split(", ").slice(1).join(", ");
+
+      let dateObj = new Date(dateStr);
+
+      let formattedDate =
+        dateObj.getFullYear() +
+        "-" +
+        (dateObj.getMonth() + 1).toString().padStart(2, "0") +
+        "-" +
+        dateObj.getDate().toString().padStart(2, "0");
+
+      document.getElementById("event-id").value = "";
+      document.getElementById("event-title").value = "";
+      document.getElementById("event-category").value = "";
+      document.getElementById("event-date").value = formattedDate;
+      document.getElementById("event-time").value = "";
+      document.getElementById("event-description").value = "";
+
+      eventModal.style.display = "flex";
     });
 
     document.querySelectorAll(".delete-button").forEach((button) => {
@@ -448,7 +477,6 @@ document.addEventListener("DOMContentLoaded", () => {
     eventForm.reset();
     renderCalendar(currentDate);
     renderTodaySection();
-    renderUpcomingSection();
   });
 
   /**
@@ -494,7 +522,6 @@ document.addEventListener("DOMContentLoaded", () => {
     localStorage.setItem("events", JSON.stringify(events));
     renderCalendar(currentDate);
     renderTodaySection();
-    renderUpcomingSection();
   };
 
   document.addEventListener("click", (event) => {

--- a/source/calendar/calendar-page.html
+++ b/source/calendar/calendar-page.html
@@ -85,9 +85,12 @@
         </div>
         <div id="calendar-grid"></div>
         <!-- Day view container -->
-        <div id="day-view" class="day-view-container" style="display: none;">
-          <div class="hours-column"></div>
-          <div class="tasks-column"></div>
+        <div id = "day-view-button-container" class="day-view-button">
+          <button class="add-button" style="display: none;">Add Task</button>
+          <div id="day-view" class="day-view-container" style="display: none;">
+            <div class="hours-column"></div>
+            <div class="tasks-column"></div>
+          </div>
         </div>
       </main>
     </div>

--- a/source/calendar/calendar-page.html
+++ b/source/calendar/calendar-page.html
@@ -117,7 +117,7 @@
           </div>
           <div class="form-group">
             <label for="event-time">Event Time:</label>
-            <input type="time" id="event-time" name="event-time" />
+            <input type="time" id="event-time" name="event-time" required />
           </div>
           <div class="form-group">
             <label for="event-category">Category:</label>

--- a/source/calendar/calendar-style.css
+++ b/source/calendar/calendar-style.css
@@ -318,6 +318,11 @@ body {
   right: 10px;
 }
 
+.results:hover {
+  cursor:pointer;
+  outline: 2px solid #74cbdf;
+}
+
 /* Added styles for category filter dropdown */
 .category-filter {
   background-color: rgba(32, 154, 182, 0.47);

--- a/source/calendar/calendar-style.css
+++ b/source/calendar/calendar-style.css
@@ -106,6 +106,10 @@ body {
   font-size: 1em;
 }
 
+.view-selector:hover, #search-bar:hover, .add-button:hover, .nav-button:hover {
+  background-color: rgba(32, 155, 182, 0.867);
+}
+
 #search-bar {
   width: 200px;
 }
@@ -146,6 +150,18 @@ body {
 .day:hover {
   background-color: #007bff;
   color: white;
+}
+
+.add-button {
+  background-color: rgba(32, 154, 182, 0.47);
+  border: 2px solid #3e8d9f;
+  color: white;
+  border-radius: 5px;
+  padding: 10px;
+  cursor: pointer;
+  font-size: 1em;
+  margin-bottom: 10px;
+  width: 100%;
 }
 
 .day.current-day {
@@ -334,6 +350,11 @@ body {
   height: 100%;
   overflow-y: auto;
   box-sizing: border-box;
+}
+
+.day-view-button-container {
+  display: flex;
+  flex-direction: column;
 }
 
 .hours-column {


### PR DESCRIPTION
### Objectives
Fixed search functionality to make it more intuitive to use and generally cleaner visually. This was done by making it so that the screen that shows up once a user initiates a search is the same screen regardless of what calendar view the user is on. Also, made some general quality of life improvements on it. Added an Add Task button and made it so that you cannot create a new task without putting down a time, to avoid complications with the day view. 

Closes issue #119 

https://github.com/cse110-sp24-group30/cse110-sp24-group30/assets/147003715/6c4e0bf1-fe08-4c59-a2b8-b9b9f2045a8b


### Acceptance Criteria
- [x] Make a universal screen that shows up when the user interacts with the search bar regardless of calendar view
- [x] Add more reactivity to the search results to show that you can interact with them directly
- [x] Make it so that once you empty out the search bar, the search screen disappears and you can continue looking at the calendar as you were before

### Assignees
- @UKCSD 

### Reviewers:
- @kabirsachdev7 